### PR TITLE
impr: add rebind constructor

### DIFF
--- a/test/allocation-test.cpp
+++ b/test/allocation-test.cpp
@@ -40,6 +40,9 @@ struct fault_injection_allocator {
 
   fault_injection_allocator() = default;
 
+  template <typename U>
+  constexpr fault_injection_allocator(const fault_injection_allocator<U>&) noexcept {}
+
   T* allocate(size_t count) {
     return static_cast<T*>(injected_allocate(count * sizeof(T)));
   }


### PR DESCRIPTION
Add a rebind constructor to maintain `proxy` objects in `_DEBUG` mode