### PR TITLE
Test deleter copy count

### DIFF
--- a/test/shared-ptr-test.cpp
+++ b/test/shared-ptr-test.cpp
@@ -221,17 +221,21 @@ TEST_F(shared_ptr_test, reset_ptr_inheritance) {
 
 TEST_F(shared_ptr_test, custom_deleter) {
   bool deleted = false;
-  { shared_ptr<test_object> p(new test_object(42), tracking_deleter<test_object>(&deleted)); }
+  bool copied = false;
+  { shared_ptr<test_object> p(new test_object(42), tracking_deleter<test_object>(&deleted, &copied)); }
   EXPECT_TRUE(deleted);
+  EXPECT_FALSE(copied);
 }
 
 TEST_F(shared_ptr_test, custom_deleter_reset) {
   bool deleted = false;
+  bool copied = false;
   {
     shared_ptr<test_object> p;
-    p.reset(new test_object(42), tracking_deleter<test_object>(&deleted));
+    p.reset(new test_object(42), tracking_deleter<test_object>(&deleted, &copied));
   }
   EXPECT_TRUE(deleted);
+  EXPECT_FALSE(copied);
 }
 
 TEST_F(shared_ptr_test, aliasing_ctor) {

--- a/test/shared-ptr-test.cpp
+++ b/test/shared-ptr-test.cpp
@@ -221,21 +221,17 @@ TEST_F(shared_ptr_test, reset_ptr_inheritance) {
 
 TEST_F(shared_ptr_test, custom_deleter) {
   bool deleted = false;
-  bool copied = false;
-  { shared_ptr<test_object> p(new test_object(42), tracking_deleter<test_object>(&deleted, &copied)); }
+  { shared_ptr<test_object> p(new test_object(42), tracking_deleter<test_object>(&deleted)); }
   EXPECT_TRUE(deleted);
-  EXPECT_FALSE(copied);
 }
 
 TEST_F(shared_ptr_test, custom_deleter_reset) {
   bool deleted = false;
-  bool copied = false;
   {
     shared_ptr<test_object> p;
-    p.reset(new test_object(42), tracking_deleter<test_object>(&deleted, &copied));
+    p.reset(new test_object(42), tracking_deleter<test_object>(&deleted));
   }
   EXPECT_TRUE(deleted);
-  EXPECT_FALSE(copied);
 }
 
 TEST_F(shared_ptr_test, aliasing_ctor) {

--- a/test/test-classes.h
+++ b/test/test-classes.h
@@ -4,13 +4,10 @@
 
 template <typename T>
 struct tracking_deleter {
-  explicit tracking_deleter(bool* deleted, bool* copied) : deleted(deleted), copied(copied) {}
+  explicit tracking_deleter(bool* deleted) : deleted(deleted) {}
 
-  tracking_deleter(tracking_deleter&& other) = default;
-
-  tracking_deleter(const tracking_deleter& other) : deleted(other.deleted), copied(other.copied) {
-    *copied = true;
-  }
+  tracking_deleter(const tracking_deleter&) = delete;
+  tracking_deleter(tracking_deleter&&) = default;
 
   void operator()(T* object) {
     *deleted = true;
@@ -19,7 +16,6 @@ struct tracking_deleter {
 
 private:
   bool* deleted;
-  bool* copied;
 };
 
 struct destruction_tracker_base {

--- a/test/test-classes.h
+++ b/test/test-classes.h
@@ -4,7 +4,13 @@
 
 template <typename T>
 struct tracking_deleter {
-  explicit tracking_deleter(bool* deleted) : deleted(deleted) {}
+  explicit tracking_deleter(bool* deleted, bool* copied) : deleted(deleted), copied(copied) {}
+
+  tracking_deleter(tracking_deleter&& other) = default;
+
+  tracking_deleter(const tracking_deleter& other) : deleted(other.deleted), copied(other.copied) {
+    *copied = true;
+  }
 
   void operator()(T* object) {
     *deleted = true;
@@ -13,6 +19,7 @@ struct tracking_deleter {
 
 private:
   bool* deleted;
+  bool* copied;
 };
 
 struct destruction_tracker_base {


### PR DESCRIPTION
Добавил в `shared_ptr_test` в `custom_deleter` и `custom_deleter_reset` проверку на то, что не происходит копирования deleter'а

От deleter'а в `std::shared_ptr` требуется CopyConstructible, поэтому просто оставить только move конструктор нельзя